### PR TITLE
Added hyperlinks to table of contents

### DIFF
--- a/september-22-2017.md
+++ b/september-22-2017.md
@@ -7,7 +7,7 @@
 ### Contents:
 
 1. ##### [September Board of Directors Meeting](#september-board-of-directors-meeting-1)
-2. ##### [Learner Engagement Model](#learner-engagement-model-v1#)
+2. ##### [Learner Engagement Model](#learner-engagement-model-v1)
 3. ##### [Design Challenges](#design-challenges-1)
 4. ##### [New Staff Role: Learner Experience Design](#new-staff-role-learner-experience-design-1)
 5. ##### [Anchor Challenge](#anchor-challenge-1)

--- a/september-22-2017.md
+++ b/september-22-2017.md
@@ -6,11 +6,11 @@
 
 ### Contents:
 
-1. ##### [September Board of Directors Meeting](#september-board-of-directors-meeting)
+1. ##### [September Board of Directors Meeting](#september-board-of-directors-meeting-1)
 2. ##### [Learner Engagement Model](#learner-engagement-model-v1#)
-3. ##### [Design Challenges](#design-challenges)
-4. ##### [New Staff Role: Learner Experience Design](#new-staff-role-learner-experience-design)
-5. ##### [Anchor Challenge](#anchor-challenge)
+3. ##### [Design Challenges](#design-challenges-1)
+4. ##### [New Staff Role: Learner Experience Design](#new-staff-role-learner-experience-design-1)
+5. ##### [Anchor Challenge](#anchor-challenge-1)
 
 ---
 

--- a/september-22-2017.md
+++ b/september-22-2017.md
@@ -6,11 +6,11 @@
 
 ### Contents:
 
-1. ##### September Board of Directors Meeting
-2. ##### Learner Engagement Model
-3. ##### Design Challenges
-4. ##### New Staff Role: Learner Experience Design
-5. ##### Anchor Challenge
+1. ##### [September Board of Directors Meeting](#september-board-of-directors-meeting)
+2. ##### [Learner Engagement Model](learner-engagement-model-v1#)
+3. ##### [Design Challenges](#design-challenges)
+4. ##### [New Staff Role: Learner Experience Design](#new-staff-role-learner-experience-design)
+5. ##### [Anchor Challenge](#anchor-challenge)
 
 ---
 

--- a/september-22-2017.md
+++ b/september-22-2017.md
@@ -7,7 +7,7 @@
 ### Contents:
 
 1. ##### [September Board of Directors Meeting](#september-board-of-directors-meeting)
-2. ##### [Learner Engagement Model](learner-engagement-model-v1#)
+2. ##### [Learner Engagement Model](#learner-engagement-model-v1#)
 3. ##### [Design Challenges](#design-challenges)
 4. ##### [New Staff Role: Learner Experience Design](#new-staff-role-learner-experience-design)
 5. ##### [Anchor Challenge](#anchor-challenge)


### PR DESCRIPTION
Clicking on a link jumps to the target header. In the long run this method will be tedious, compared with use of a package that automatically generates and updates a table of contents.